### PR TITLE
Fix Noise

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -1527,7 +1527,7 @@ function Q5(scope, parent) {
 	var perlin_octaves = 4;
 	var perlin_amp_falloff = 0.5;
 	var scaled_cosine = (i) => {
-		return 0.5 * (1.0 - $.cos(i * Math.PI));
+		return 0.5 * (1.0 - Math.cos(i * Math.PI));
 	};
 	var p_perlin;
 


### PR DESCRIPTION
In p5 we use Math.cos
To be a drag and drop replacement we should follow those standards so that noise will produce the same output Currently we get noise from this.cos which does Not return the same cos value as math.cos