### PR TITLE
Support for .parent

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -250,7 +250,19 @@ function Q5(scope, parent) {
 		$.canvas.height = height * $._pixelDensity;
 		defaultStyle();
 		if (scope != 'graphics' && scope != 'image') $.pixelDensity(2);
-		return $.canvas;
+
+		// Create a wrapper object that includes the canvas and parent function
+		let canvasObject = {
+			canvas: $.canvas,
+			parent: function (id) {
+				let parentElement = document.getElementById(id);
+				if (parentElement) {
+					parentElement.appendChild(this.canvas);
+				}
+			}
+		};
+
+		return canvasObject;
 	};
 
 	$.resizeCanvas = (width, height) => {


### PR DESCRIPTION
In p5 you can do this
 let renderer = p.createCanvas(p.windowWidth, p.windowHeight);
    renderer.parent("homebackground");

This adds support for this style of page casting to an element