### PR TITLE
Better page resize

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -35,8 +35,12 @@ function Q5(scope, parent) {
 
 		$.canvas.parent = (el) => {
 			if (typeof el === 'string') el = document.getElementById(el);
-			el.append($.canvas);
-			resizeObserver.observe(el);
+			else {
+				try {
+					if (el instanceof p5.Element || el instanceof q5.Element) el = el.elt;
+				} catch (e) {}
+			}
+			el instanceof Node ? el.append($.canvas) : console.error("Invalid parent element provided");
 		};
 
 		let defaultParent = document.getElementsByTagName('main')[0];
@@ -46,7 +50,6 @@ function Q5(scope, parent) {
 		}
 		resizeObserver.observe(defaultParent);
 		parent ??= defaultParent;
-
 		if (document.body) {
 			if (parent?.append) {
 				parent.append($.canvas);
@@ -56,6 +59,9 @@ function Q5(scope, parent) {
 		} else {
 			window.addEventListener('load', () => {
 				document.body.appendChild($.canvas);
+
+				// Start observing the body as it is the default parent now.
+				resizeObserver.observe(document.body);
 			});
 		}
 	}

--- a/q5.js
+++ b/q5.js
@@ -28,16 +28,23 @@ function Q5(scope, parent) {
 	$.windowResized = () => {};
 
 	if (scope != 'graphics' && scope != 'image') {
+		const resizeObserver = new ResizeObserver(() => {
+			$.windowResized();
+		});
 		window.addEventListener('resize', () => $.windowResized());
+
 		$.canvas.parent = (el) => {
 			if (typeof el === 'string') el = document.getElementById(el);
 			el.append($.canvas);
+			resizeObserver.observe(el);
 		};
+
 		let defaultParent = document.getElementsByTagName('main')[0];
 		if (!defaultParent) {
 			console.warn("Default <main> element not found. Using document.body instead.");
 			defaultParent = document.body;
 		}
+		resizeObserver.observe(defaultParent);
 		parent ??= defaultParent;
 
 		if (document.body) {

--- a/q5.js
+++ b/q5.js
@@ -30,13 +30,22 @@ function Q5(scope, parent) {
 	if (scope != 'graphics' && scope != 'image') {
 		window.addEventListener('resize', () => $.windowResized());
 		$.canvas.parent = (el) => {
-			if (el[0]) el = document.getElementById(el);
+			if (typeof el === 'string') el = document.getElementById(el);
 			el.append($.canvas);
 		};
+		let defaultParent = document.getElementsByTagName('main')[0];
+		if (!defaultParent) {
+			console.warn("Default <main> element not found. Using document.body instead.");
+			defaultParent = document.body;
+		}
+		parent ??= defaultParent;
+
 		if (document.body) {
-			parent ??= document.getElementsByTagName('main')[0];
-			if (parent?.append) parent.append($.canvas);
-			else document.body.appendChild($.canvas);
+			if (parent?.append) {
+				parent.append($.canvas);
+			} else {
+				document.body.appendChild($.canvas);
+			}
 		} else {
 			window.addEventListener('load', () => {
 				document.body.appendChild($.canvas);


### PR DESCRIPTION
Adds a Resize Observer to our element.

Ok bit of a long talk here.
When we call many elements of p5 or q5 and they are in div boxes that may shrink or grow, if we set the width of each on setup the sizes can change based on css rules and other page timings. With the way p5 works there is certain cases where you have to call resize 2 times to make sure that it fills the full div box. Using ResizeObserver we can make sure that all the resize calls not just ones post load are called. This does mean that we may see 2 calls to window resize on a resize but the only way to avoid  would be logic to check if the resize size and last resize size are the same, which may cause problems. This also means we do not perfectly mimic p5, but the difference should be minimal and only changes flexboxes and other css problems. In any case this helps solve all resize issues due to page size on setup in a flex box.

This branch is here mostly for my code, Thanks