### PR TITLE
Move listener after init

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -1975,12 +1975,10 @@ function Q5(scope, parent) {
 		keysHeld[$.keyCode] = false;
 		$._keyReleasedFn(e);
 	};
-	addEventListener('mousemove', (e) => $._onmousemove(e), false);
+
 	$.canvas.onmousedown = (e) => $._onmousedown(e);
 	$.canvas.onmouseup = (e) => $._onmouseup(e);
 	$.canvas.onclick = (e) => $._onclick(e);
-	addEventListener('keydown', (e) => $._onkeydown(e), false);
-	addEventListener('keyup', (e) => $._onkeyup(e), false);
 	$.keyIsDown = (x) => !!keysHeld[x];
 
 	function getTouchInfo(touch) {
@@ -2254,6 +2252,9 @@ function Q5(scope, parent) {
 			}
 			_start();
 		}
+	addEventListener('mousemove', (e) => $._onmousemove(e), false);
+	addEventListener('keydown', (e) => $._onkeydown(e), false);
+	addEventListener('keyup', (e) => $._onkeyup(e), false);
 	}
 	if (scope == 'global') _init();
 	else requestAnimationFrame(_init);


### PR DESCRIPTION
If you load a sketch while holding a key or mouse. Or while moving quickly, you can get an error of Uncaught TypeError: this._mouseMovedFn is not a function.

This is because the listener can call before the function is declared. By moving the listener to the end of the init chain we make sure that all methods are initialized before calling.