### PR TITLE
Observe el Element

### DIFF
--- a/q5.js
+++ b/q5.js
@@ -38,7 +38,7 @@ function Q5(scope, parent) {
 			if (typeof ResizeObserver != 'undefined') {
 				if ($._ro) $._ro.disconnect();
 				$._ro = new ResizeObserver($._resize);
-				$._ro.observe(parent);
+				$._ro.observe(el);
 			} else if ($.frameCount == 0) {
 				addEventListener('resize', $._resize);
 			}


### PR DESCRIPTION
This is observing the whole parent element, after looking into it I think we just want to observe our element `el` Like this `$._ro.observe(el);`

From my understanding

Observing el: It observes the element to which the canvas gets appended.
Observing parent: This would be the outer container where you initially intended to place the canvas. Observing parent would be useful if there are multiple things inside parent and you want to trigger a resize whenever anything inside parent changes size or when parent itself changes size.