### PR TITLE
Fix README broken logo issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="q5js_logo.png" height="64"> <img src="q5js_brand.png" height="64">
+# <img src="q5js_logo.webp" height="64"> <img src="q5js_brand.webp" height="64">
 
 **q5.js** implements all of [p5][]'s 2D drawing, math, and user input functionality.
 


### PR DESCRIPTION
This appears to have been an issue since 1.9.8 (d9a16a3), when the two files `q5js_logo.png` and `q5js_brand.png` were converted from PNG to WebP format without properly updating the links in the README file:

<img src="https://github.com/quinton-ashley/q5.js/assets/49850194/5a55813b-cf25-4aad-a56d-4414f3483a1c" width=240>
<img src="https://github.com/quinton-ashley/q5.js/assets/49850194/d349f9e3-e19c-4d1f-a897-98454582dd0d" width=240>
